### PR TITLE
[unitaryhack] Adding a power wrapper for Gates.

### DIFF
--- a/src/orquestra/quantum/circuits/_gates.py
+++ b/src/orquestra/quantum/circuits/_gates.py
@@ -136,7 +136,7 @@ class GateOperation:
 
     def apply(self, amplitude_vector: ParameterizedVector) -> ParameterizedVector:
         num_qubits = np.log2(len(amplitude_vector))
-        if 2**num_qubits != len(amplitude_vector):
+        if 2 ** num_qubits != len(amplitude_vector):
             raise ValueError(
                 "GateOperation can only be applied to multi-qubit state vector but "
                 f"vector of length {len(amplitude_vector)} was provided."
@@ -277,7 +277,7 @@ class ControlledGate(Gate):
     @property
     def matrix(self):
         return sympy.Matrix.diag(
-            sympy.eye(2**self.num_qubits - 2**self.wrapped_gate.num_qubits),
+            sympy.eye(2 ** self.num_qubits - 2 ** self.wrapped_gate.num_qubits),
             self.wrapped_gate.matrix,
         )
 
@@ -406,7 +406,7 @@ class Power(Gate):
 
 def _n_qubits(matrix):
     n_qubits = math.floor(math.log2(matrix.shape[0]))
-    if 2**n_qubits != matrix.shape[0] or 2**n_qubits != matrix.shape[1]:
+    if 2 ** n_qubits != matrix.shape[0] or 2 ** n_qubits != matrix.shape[1]:
         raise ValueError("Gate's matrix has to be square with dimension 2^N")
     return n_qubits
 

--- a/src/orquestra/quantum/circuits/_gates.py
+++ b/src/orquestra/quantum/circuits/_gates.py
@@ -136,7 +136,7 @@ class GateOperation:
 
     def apply(self, amplitude_vector: ParameterizedVector) -> ParameterizedVector:
         num_qubits = np.log2(len(amplitude_vector))
-        if 2 ** num_qubits != len(amplitude_vector):
+        if 2**num_qubits != len(amplitude_vector):
             raise ValueError(
                 "GateOperation can only be applied to multi-qubit state vector but "
                 f"vector of length {len(amplitude_vector)} was provided."
@@ -277,7 +277,7 @@ class ControlledGate(Gate):
     @property
     def matrix(self):
         return sympy.Matrix.diag(
-            sympy.eye(2 ** self.num_qubits - 2 ** self.wrapped_gate.num_qubits),
+            sympy.eye(2**self.num_qubits - 2**self.wrapped_gate.num_qubits),
             self.wrapped_gate.matrix,
         )
 
@@ -383,7 +383,7 @@ class Power(Gate):
 
     @property
     def matrix(self) -> sympy.Matrix:
-        return self.wrapped_gate.matrix ** self.exponent
+        return self.wrapped_gate.matrix**self.exponent
 
     def controlled(self, num_control_qubits: int) -> "Gate":
         return self.wrapped_gate.controlled(num_control_qubits).power(self.exponent)
@@ -406,7 +406,7 @@ class Power(Gate):
 
 def _n_qubits(matrix):
     n_qubits = math.floor(math.log2(matrix.shape[0]))
-    if 2 ** n_qubits != matrix.shape[0] or 2 ** n_qubits != matrix.shape[1]:
+    if 2**n_qubits != matrix.shape[0] or 2**n_qubits != matrix.shape[1]:
         raise ValueError("Gate's matrix has to be square with dimension 2^N")
     return n_qubits
 

--- a/src/orquestra/quantum/circuits/_gates.py
+++ b/src/orquestra/quantum/circuits/_gates.py
@@ -89,6 +89,12 @@ class Gate(Protocol):
     def dagger(self) -> "Gate":
         raise NotImplementedError()
 
+    def power(self, exponent: float) -> "Gate":
+        """Gate representing the underlying matrix raised to the power
+        of the given exponent.
+        """
+        raise NotImplementedError()
+
     def bind(self, symbols_map: Dict[sympy.Symbol, Parameter]) -> "Gate":
         raise NotImplementedError()
 
@@ -208,6 +214,9 @@ class MatrixFactoryGate:
     def dagger(self) -> Union["MatrixFactoryGate", Gate]:
         return self if self.is_hermitian else Dagger(self)
 
+    def power(self, exponent: float) -> "Gate":
+        return Power(self, exponent)
+
     def __str__(self):
         return (
             f"{self.name}({', '.join(map(str,self.params))})"
@@ -289,6 +298,12 @@ class ControlledGate(Gate):
             num_control_qubits=self.num_control_qubits,
         )
 
+    def power(self, exponent: float) -> "Gate":
+        return ControlledGate(
+            wrapped_gate=self.wrapped_gate.power(exponent),
+            num_control_qubits=self.num_control_qubits,
+        )
+
     def bind(self, symbols_map) -> "Gate":
         return self.wrapped_gate.bind(symbols_map).controlled(self.num_control_qubits)
 
@@ -333,6 +348,60 @@ class Dagger(Gate):
     @property
     def dagger(self) -> "Gate":
         return self.wrapped_gate
+
+    def power(self, exponent: float) -> "Gate":
+        return Power(self, exponent)
+
+
+POWER_GATE_SYMBOL = "^"
+
+
+@dataclass(frozen=True)
+class Power(Gate):
+    wrapped_gate: Gate
+    exponent: float
+
+    def __post_init__(self):
+        if len(self.wrapped_gate.free_symbols) > 0:
+            raise ValueError("Gates with free symbols cannot be exponentiated")
+
+    @property
+    def name(self) -> str:
+        return f"{self.wrapped_gate.name}{POWER_GATE_SYMBOL}{self.exponent}"
+
+    @property
+    def params(self) -> Tuple[Parameter, ...]:
+        return self.wrapped_gate.params
+
+    @property
+    def free_symbols(self) -> Iterable[sympy.Symbol]:
+        return get_free_symbols(self.params)
+
+    @property
+    def num_qubits(self) -> int:
+        return self.wrapped_gate.num_qubits
+
+    @property
+    def matrix(self) -> sympy.Matrix:
+        return self.wrapped_gate.matrix ** self.exponent
+
+    def controlled(self, num_control_qubits: int) -> "Gate":
+        return self.wrapped_gate.controlled(num_control_qubits).power(self.exponent)
+
+    @property
+    def dagger(self) -> "Gate":
+        return self.wrapped_gate.dagger.power(self.exponent)
+
+    def power(self, exponent: float) -> "Gate":
+        return Power(self, exponent)
+
+    def bind(self, symbols_map: Dict[sympy.Symbol, Parameter]) -> "Gate":
+        raise NotImplementedError(
+            "Gates raised to a power do not possess free symbols to bind",
+        )
+
+    def replace_params(self, new_params: Tuple[Parameter, ...]) -> "Gate":
+        return self.wrapped_gate.replace_params(new_params).power(self.exponent)
 
 
 def _n_qubits(matrix):

--- a/src/orquestra/quantum/circuits/_serde.py
+++ b/src/orquestra/quantum/circuits/_serde.py
@@ -165,6 +165,15 @@ def _dagger_gate_to_dict(gate: _gates.Dagger):
     }
 
 
+@to_dict.register
+def _power_gate_to_dict(gate: _gates.Power):
+    return {
+        "name": gate.name,
+        "wrapped_gate": to_dict(gate.wrapped_gate),
+        "exponent": gate.exponent,
+    }
+
+
 # ---------- deserialization ----------
 
 
@@ -231,6 +240,10 @@ def _special_gate_from_dict(dict_, custom_gate_defs) -> _gates.Gate:
     elif dict_["name"] == _gates.DAGGER_GATE_NAME:
         wrapped_gate = _gate_from_dict(dict_["wrapped_gate"], custom_gate_defs)
         return _gates.Dagger(wrapped_gate)
+
+    elif _gates.POWER_GATE_SYMBOL in dict_["name"]:
+        wrapped_gate = _gate_from_dict(dict_["wrapped_gate"], custom_gate_defs)
+        return _gates.Power(wrapped_gate, dict_["exponent"])
 
     else:
         raise KeyError()

--- a/tests/orquestra/quantum/circuits/_gates_test.py
+++ b/tests/orquestra/quantum/circuits/_gates_test.py
@@ -172,7 +172,7 @@ class TestControlledGate:
         n = gate.matrix.shape[0]
         assert gate.matrix.shape[1] == n
         assert controlled_gate.matrix[0:-n, 0:-n] == sympy.eye(
-            2 ** controlled_gate.num_qubits - n
+            2**controlled_gate.num_qubits - n
         )
         assert controlled_gate.matrix[-n:, -n:] == gate.matrix
 
@@ -255,7 +255,7 @@ class TestPowerGate:
         self, gate, exponent
     ):
         if len(gate.free_symbols) == 0:
-            wrapped_gate_matrix_exponentiated = gate.matrix ** exponent
+            wrapped_gate_matrix_exponentiated = gate.matrix**exponent
             assert gate.power(exponent).matrix == wrapped_gate_matrix_exponentiated
 
     def test_dagger_of_power_gate_power_gate_of_dagger(self, gate, exponent):
@@ -267,7 +267,7 @@ class TestPowerGate:
         if len(gate.free_symbols) == 0:
             power_gate = gate.power(exponent)
             powered_power_gate = power_gate.power(exponent)
-            assert powered_power_gate.matrix == power_gate.matrix ** exponent
+            assert powered_power_gate.matrix == power_gate.matrix**exponent
 
     def test_parameter_binding_not_implemented_for_power_gates(self, gate, exponent):
         if len(gate.free_symbols) == 0:
@@ -314,6 +314,6 @@ class TestGateOperation:
         assert op.free_symbols == gate.free_symbols
 
     def test_cannot_be_applied_to_vector_of_not_power_of_two_length(self, gate):
-        state_vector = np.array([0.1 for _ in range(2 ** gate.num_qubits + 1)])
+        state_vector = np.array([0.1 for _ in range(2**gate.num_qubits + 1)])
         with pytest.raises(ValueError):
             GateOperation(gate, tuple(range(gate.num_qubits))).apply(state_vector)

--- a/tests/orquestra/quantum/circuits/_gates_test.py
+++ b/tests/orquestra/quantum/circuits/_gates_test.py
@@ -33,12 +33,7 @@ GATES_REPRESENTATIVES = [
     _builtin_gates.CPHASE(1.5),
 ]
 
-POWER_GATE_EXPONENTS = [
-    -2.0,
-    0,
-    0.5,
-    1.0
-]
+POWER_GATE_EXPONENTS = [-2.0, 0, 0.5, 1.0]
 
 
 def example_one_qubit_matrix_factory(a, b):
@@ -173,7 +168,7 @@ class TestControlledGate:
         n = gate.matrix.shape[0]
         assert gate.matrix.shape[1] == n
         assert controlled_gate.matrix[0:-n, 0:-n] == sympy.eye(
-            2**controlled_gate.num_qubits - n
+            2 ** controlled_gate.num_qubits - n
         )
         assert controlled_gate.matrix[-n:, -n:] == gate.matrix
 
@@ -255,9 +250,7 @@ class TestPowerGate:
         if len(gate.free_symbols) == 0:
             assert gate.power(exponent).free_symbols == gate.free_symbols
 
-    def test_has_same_number_of_qubits_as_wrapped_gate(
-        self, gate, exponent
-    ):
+    def test_has_same_number_of_qubits_as_wrapped_gate(self, gate, exponent):
         if len(gate.free_symbols) == 0:
             assert gate.power(exponent).num_qubits == gate.num_qubits
 
@@ -279,9 +272,7 @@ class TestPowerGate:
             powered_power_gate = power_gate.power(exponent)
             assert powered_power_gate.matrix == power_gate.matrix ** exponent
 
-    def test_parameter_binding_not_implemented_for_power_gates(
-        self, gate, exponent
-    ):
+    def test_parameter_binding_not_implemented_for_power_gates(self, gate, exponent):
         if len(gate.free_symbols) == 0:
             power_gate = gate.power(exponent)
             symbols_map = {sympy.Symbol("theta"): 0.5, sympy.Symbol("x"): 3}
@@ -326,6 +317,6 @@ class TestGateOperation:
         assert op.free_symbols == gate.free_symbols
 
     def test_cannot_be_applied_to_vector_of_not_power_of_two_length(self, gate):
-        state_vector = np.array([0.1 for _ in range(2**gate.num_qubits + 1)])
+        state_vector = np.array([0.1 for _ in range(2 ** gate.num_qubits + 1)])
         with pytest.raises(ValueError):
             GateOperation(gate, tuple(range(gate.num_qubits))).apply(state_vector)

--- a/tests/orquestra/quantum/circuits/_gates_test.py
+++ b/tests/orquestra/quantum/circuits/_gates_test.py
@@ -9,7 +9,7 @@ import pytest
 import sympy
 
 from orquestra.quantum.circuits import _builtin_gates, _gates
-from orquestra.quantum.circuits._gates import GateOperation, MatrixFactoryGate
+from orquestra.quantum.circuits._gates import GateOperation, MatrixFactoryGate, Power
 
 GATES_REPRESENTATIVES = [
     _builtin_gates.X,
@@ -124,6 +124,10 @@ class TestMatrixFactoryGate:
         )
         assert gate.dagger is gate
 
+    def test_power_of_dagger_is_dagger_wrapped_by_power(self):
+        gate = MatrixFactoryGate("V", example_one_qubit_matrix_factory, (1, 0), 1)
+        assert gate.dagger.power(0.5) == Power(gate.dagger, 0.5)
+
     def test_binding_gates_in_dagger_is_propagated_to_wrapped_gate(self):
         theta = sympy.Symbol("theta")
         gate = MatrixFactoryGate("V", example_one_qubit_matrix_factory, (theta, 0), 1)
@@ -218,13 +222,6 @@ class TestControlledGate:
     def test_constructing_controlled_gate_with_zero_control_raises_error(self, gate):
         with pytest.raises(ValueError):
             gate.controlled(0)
-
-
-@pytest.mark.parametrize("gate", GATES_REPRESENTATIVES)
-class TestDagger:
-    def test_power_of_dagger(self, gate):
-        if len(gate.free_symbols) == 0:
-            gate.dagger.power(0.5)
 
 
 @pytest.mark.parametrize("gate", GATES_REPRESENTATIVES)

--- a/tests/orquestra/quantum/circuits/_serde_test.py
+++ b/tests/orquestra/quantum/circuits/_serde_test.py
@@ -128,6 +128,12 @@ EXAMPLE_CIRCUITS = [
             _builtin_gates.RY(PARAMETER_VECTOR[0] * PARAMETER_VECTOR[1])(1),
         ]
     ),
+    _circuit.Circuit(
+        [
+            _builtin_gates.Z.power(0.25)(0),
+            _builtin_gates.SWAP.power(0.5)(0, 1),
+        ]
+    ),
 ]
 
 


### PR DESCRIPTION
## Description

Fixes [orquestra-core/#14](https://github.com/zapatacomputing/orquestra-core/issues/14) by adding a power wrapper for `Gate` instances. The wrapper allows arbitrary powers of existing gates to be used without having to explicitly define them in code. This adds additional flexibity for those using Orquestra.
