### PR TITLE
Fix typing_extensions.

### DIFF
--- a/src/orquestra/quantum/api/estimation.py
+++ b/src/orquestra/quantum/api/estimation.py
@@ -2,10 +2,9 @@
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Protocol
 
 import numpy as np
-from typing_extensions import Protocol
 
 from orquestra.quantum.circuits import Circuit
 

--- a/src/orquestra/quantum/circuits/_gates.py
+++ b/src/orquestra/quantum/circuits/_gates.py
@@ -4,11 +4,10 @@
 """Data structures for orquestra gates."""
 import math
 from dataclasses import dataclass, replace
-from typing import Callable, Dict, Iterable, Tuple, Union
+from typing import Callable, Dict, Iterable, Protocol, Tuple, Union, runtime_checkable
 
 import numpy as np
 import sympy
-from typing_extensions import Protocol, runtime_checkable
 
 from orquestra.quantum.typing import ParameterizedVector
 

--- a/src/orquestra/quantum/circuits/_operations.py
+++ b/src/orquestra/quantum/circuits/_operations.py
@@ -4,10 +4,9 @@
 from abc import abstractmethod
 from functools import singledispatch
 from numbers import Number
-from typing import Dict, Iterable, Tuple, TypeVar
+from typing import Dict, Iterable, Protocol, Tuple, TypeVar
 
 import sympy
-from typing_extensions import Protocol
 
 from orquestra.quantum.typing import Parameter, ParameterizedVector
 

--- a/src/orquestra/quantum/decompositions/_decomposition.py
+++ b/src/orquestra/quantum/decompositions/_decomposition.py
@@ -2,9 +2,7 @@
 # © Copyright 2021 Zapata Computing Inc.
 ################################################################################
 from abc import abstractmethod
-from typing import Iterable, Sequence, TypeVar
-
-from typing_extensions import Protocol
+from typing import Iterable, Protocol, Sequence, TypeVar
 
 OperationType = TypeVar("OperationType")
 

--- a/src/orquestra/quantum/typing.py
+++ b/src/orquestra/quantum/typing.py
@@ -4,11 +4,10 @@
 """Types commonly encountered in orquestra repositories."""
 from numbers import Number
 from os import PathLike
-from typing import Any, Callable, Dict, List, Sequence, Union
+from typing import Any, Dict, Protocol, Sequence, Union, runtime_checkable
 
 import numpy as np
 import sympy
-from typing_extensions import Protocol, runtime_checkable
 
 
 @runtime_checkable


### PR DESCRIPTION
## Description

After moving from Python 3.7 to 3.8 we can stop using `typing_extensions` and start using `typing` in some places. This PR makes appropriate changes.

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
