### PR TITLE
Include Precision in Estimator Contracts

### DIFF
--- a/src/orquestra/quantum/api/estimator_contract.py
+++ b/src/orquestra/quantum/api/estimator_contract.py
@@ -71,12 +71,13 @@ def _validate_order_of_outputs_matches_order_of_inputs(
 
     return all(
         [
-            np.array_equal(
+            np.allclose(
                 expectation_values[i].values,
                 estimator(
                     backend=_backend,
                     estimation_tasks=[task],
                 )[0].values,
+                rtol = 0.1 # 10% tolerance
             )
             for i, task in enumerate(_estimation_tasks)
         ]
@@ -98,8 +99,8 @@ def _validate_expectation_value_includes_coefficients(
         estimation_tasks=estimation_tasks,
     )
 
-    return not np.array_equal(
-        expectation_values[0].values, expectation_values[1].values
+    return np.allclose(
+        expectation_values[0].values, expectation_values[1].values/19.971997, rtol = 0.1 # 10% tolerance
     )
 
 

--- a/src/orquestra/quantum/api/estimator_contract.py
+++ b/src/orquestra/quantum/api/estimator_contract.py
@@ -77,7 +77,7 @@ def _validate_order_of_outputs_matches_order_of_inputs(
                     backend=_backend,
                     estimation_tasks=[task],
                 )[0].values,
-                rtol = 0.1 # 10% tolerance
+                rtol=0.1,  # 10% tolerance
             )
             for i, task in enumerate(_estimation_tasks)
         ]
@@ -87,10 +87,11 @@ def _validate_order_of_outputs_matches_order_of_inputs(
 def _validate_expectation_value_includes_coefficients(
     estimator: EstimateExpectationValues,
 ):
+    term_coefficient = 19.971997
     estimation_tasks = [
         EstimationTask(IsingOperator("Z0"), Circuit([RX(np.pi / 3)(0)]), 10000),
         EstimationTask(
-            IsingOperator("Z0", 19.971997), Circuit([RX(np.pi / 3)(0)]), 10000
+            IsingOperator("Z0", term_coefficient), Circuit([RX(np.pi / 3)(0)]), 10000
         ),
     ]
 
@@ -100,7 +101,9 @@ def _validate_expectation_value_includes_coefficients(
     )
 
     return np.allclose(
-        expectation_values[0].values, expectation_values[1].values/19.971997, rtol = 0.1 # 10% tolerance
+        expectation_values[0].values,
+        expectation_values[1].values / term_coefficient,
+        rtol=0.1,  # 10% tolerance
     )
 
 


### PR DESCRIPTION
Following discussion with Michał, I've changed _validate_order_of_outputs_matches_order_of_inputs and _validate_expectation_value_includes_coefficients to take into account non-deterministic estimators. They now test equality within a certain pre-defined precision, which I have set to a default of 10%.

## Description

Include description of feature this PR introduces or a bug that it fixes. Include the following information:

- Context: why is it needed? In case of bug, what was the cause for the bug?
- Concise description of the implemented solution.
- If any dependencies are added, list them and justify why they are needed.

## Please verify that you have completed the following steps

- [ ] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
