### PR TITLE
Virtual to phyiscal dict added to measurements

### DIFF
--- a/src/orquestra/quantum/measurements.py
+++ b/src/orquestra/quantum/measurements.py
@@ -569,6 +569,7 @@ class Measurements:
             self.bitstrings = []
         else:
             self.bitstrings = bitstrings
+        self.virtual_to_physical_qubits_dict = None
 
     @classmethod
     def from_counts(cls, counts: Dict[str, int]):


### PR DESCRIPTION
From our perspective, the Measurements object having a "virtual to physical" dictionary for qubit mapping is the easiest solution. We are not sure about issues from the software side.

Having some method of virtual to physical mapping available will be essential for our mitigation strategies to work. 