### PR TITLE
(fix): Allow PauliTerm in count_qubits

### DIFF
--- a/src/orquestra/quantum/openfermion/utils/operator_utils.py
+++ b/src/orquestra/quantum/openfermion/utils/operator_utils.py
@@ -35,7 +35,7 @@ from orquestra.quantum.openfermion.ops.representations import (
 from orquestra.quantum.openfermion.transforms.opconversions.term_reordering import (
     normal_ordered,
 )
-from orquestra.quantum.wip.operators import PauliSum
+from orquestra.quantum.wip.operators import PauliSum, PauliTerm
 
 
 class OperatorUtilsError(Exception):
@@ -139,8 +139,8 @@ def count_qubits(operator):
     Raises:
        TypeError: Operator of invalid type.
     """
-    # Handle PauliSum
-    if isinstance(operator, PauliSum):
+    # Handle PauliRepresentation
+    if isinstance(operator, PauliSum) or isinstance(operator, PauliTerm):
         if operator.qubits == set():
             return 0
         return max(operator.qubits) + 1

--- a/tests/orquestra/quantum/openfermion/utils/operator_utils_test.py
+++ b/tests/orquestra/quantum/openfermion/utils/operator_utils_test.py
@@ -50,6 +50,7 @@ from orquestra.quantum.openfermion.utils.operator_utils import (
     load_operator,
     save_operator,
 )
+from orquestra.quantum.wip.operators import PauliSum, PauliTerm
 
 
 class OperatorUtilsTest(unittest.TestCase):
@@ -62,6 +63,8 @@ class OperatorUtilsTest(unittest.TestCase):
         self.qubit_operator = jordan_wigner(self.fermion_operator)
         self.interaction_operator = get_interaction_operator(self.fermion_operator)
         self.ising_operator = IsingOperator("[Z0] + [Z1] + [Z2] + [Z3] + [Z4]")
+        self.pauli_term = PauliTerm({0: "Z", 1: "X", 2: "Y", 3: "Z", 4: "Y"}, 0.5)
+        self.pauli_sum = PauliSum([self.pauli_term])
 
     def test_n_qubits_single_fermion_term(self):
         self.assertEqual(self.n_qubits, count_qubits(self.fermion_term))
@@ -77,6 +80,12 @@ class OperatorUtilsTest(unittest.TestCase):
 
     def test_n_qubits_ising_operator(self):
         self.assertEqual(self.n_qubits, count_qubits(self.ising_operator))
+
+    def test_n_qubits_pauli_term(self):
+        self.assertEqual(self.n_qubits, count_qubits(self.pauli_term))
+
+    def test_n_qubits_pauli_sum(self):
+        self.assertEqual(self.n_qubits, count_qubits(self.pauli_sum))
 
     def test_n_qubits_bad_type(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
## Description

Small fix, needed for conversions in `orquestra-qiskit`.

## Please verify that you have completed the following steps

- [x] I have included test cases validating introduced feature/fix.
- [x] I have self-reviewed my code.
- [ ] I have updated documentation.
