### PR TITLE
ZQS 1104 use new paulis in time evolution

### DIFF
--- a/src/orquestra/quantum/api/backend.py
+++ b/src/orquestra/quantum/api/backend.py
@@ -9,16 +9,15 @@ import numpy as np
 from orquestra.quantum.circuits import Circuit, GateOperation, Operation
 from orquestra.quantum.circuits._circuit import split_circuit
 from orquestra.quantum.circuits.layouts import CircuitConnectivity
-from orquestra.quantum.openfermion import IsingOperator, QubitOperator, SymbolicOperator
 from orquestra.quantum.wavefunction import Wavefunction
-from orquestra.quantum.wip.operators import PauliRepresentation, PauliSum, PauliTerm
+from orquestra.quantum.wip.operators import PauliRepresentation
 
 from ..distributions import (
     MeasurementOutcomeDistribution,
     create_bitstring_distribution_from_probability_distribution,
 )
 from ..measurements import ExpectationValues, Measurements, expectation_values_to_real
-from ..openfermion import change_operator_type, get_expectation_value
+from ..openfermion import get_expectation_value
 
 # Note that in particular Wavefunction is a StateVector. However, for performance
 # reasons QuantumSimulator uses numpy arrays internally.

--- a/src/orquestra/quantum/api/backend_test.py
+++ b/src/orquestra/quantum/api/backend_test.py
@@ -43,7 +43,6 @@ import pytest
 
 from orquestra.quantum.api.estimation import EstimationTask
 from orquestra.quantum.circuits import CNOT, Circuit, H, X, builtin_gate_by_name
-from orquestra.quantum.openfermion import QubitOperator
 from orquestra.quantum.wavefunction import Wavefunction
 
 from ..distributions import MeasurementOutcomeDistribution
@@ -211,10 +210,10 @@ class QuantumBackendGatesTests:
 
         circuit = Circuit([gate_1, gate_2])
         operators = [
-            QubitOperator("[]"),
-            QubitOperator("[X0]"),
-            QubitOperator("[Y0]"),
-            QubitOperator("[Z0]"),
+            PauliTerm.identity(),
+            PauliTerm("X0"),
+            PauliTerm("Y0"),
+            PauliTerm("Z0"),
         ]
 
         sigma = 1 / np.sqrt(n_samples)
@@ -247,10 +246,10 @@ class QuantumBackendGatesTests:
 
         circuit = Circuit([gate_1, gate_2])
         operators = [
-            QubitOperator("[]"),
-            QubitOperator("[X0]"),
-            QubitOperator("[Y0]"),
-            QubitOperator("[Z0]"),
+            PauliTerm.identity(),
+            PauliTerm("X0"),
+            PauliTerm("Y0"),
+            PauliTerm("Z0"),
         ]
 
         sigma = 1 / np.sqrt(n_samples)
@@ -294,7 +293,7 @@ class QuantumBackendGatesTests:
 
         for i, operator in enumerate(operators):
             # When
-            operator = QubitOperator(operator)
+            operator = PauliTerm(operator)
             estimation_tasks = [EstimationTask(operator, circuit, n_samples)]
             expectation_values = estimate_expectation_values_by_averaging(
                 backend_for_gates_test, estimation_tasks
@@ -333,7 +332,7 @@ class QuantumBackendGatesTests:
 
         for i, operator in enumerate(operators):
             # When
-            operator = QubitOperator(operator)
+            operator = PauliTerm(operator)
             estimation_tasks = [EstimationTask(operator, circuit, n_samples)]
             expectation_values = estimate_expectation_values_by_averaging(
                 backend_for_gates_test, estimation_tasks

--- a/src/orquestra/quantum/evolution.py
+++ b/src/orquestra/quantum/evolution.py
@@ -59,8 +59,6 @@ def time_evolution_for_term(
         Circuit: Circuit representing evolved term.
     """
 
-    if len(term.terms) != 1:
-        raise ValueError("This function works only on a single term.")
     base_changes = []
     base_reversals = []
     cnot_gates = []
@@ -81,7 +79,7 @@ def time_evolution_for_term(
         elif term_type == "Y":
             base_changes.append(RX(np.pi / 2)(qubit_id))
             base_reversals.append(RX(-np.pi / 2)(qubit_id))
-        if i == len(term._ops) - 1:
+        if i == len(term.operations) - 1:
             central_gate = RZ(2 * time * term.coefficient)(qubit_id)
         else:
             cnot_gates.append(CNOT(qubit_id, qubit_indices[i + 1]))

--- a/src/orquestra/quantum/evolution.py
+++ b/src/orquestra/quantum/evolution.py
@@ -5,18 +5,18 @@
 import operator
 from functools import reduce
 from itertools import chain
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import sympy
 
 from orquestra.quantum import circuits
 from orquestra.quantum.circuits import CNOT, RX, RZ, H
-from orquestra.quantum.openfermion import QubitOperator
+from orquestra.quantum.wip.operators import PauliRepresentation, PauliTerm
 
 
 def time_evolution(
-    hamiltonian: QubitOperator,
+    hamiltonian: PauliRepresentation,
     time: Union[float, sympy.Expr],
     method: str = "Trotter",
     trotter_order: int = 1,
@@ -36,20 +36,18 @@ def time_evolution(
     if method != "Trotter":
         raise ValueError(f"Currently the method {method} is not supported.")
 
-    terms: Iterable = list(hamiltonian.get_operators())
-
     return reduce(
         operator.add,
         (
             time_evolution_for_term(term, time / trotter_order)
             for _index_order in range(trotter_order)
-            for term in terms
+            for term in hamiltonian.terms
         ),
     )
 
 
 def time_evolution_for_term(
-    term: QubitOperator, time: Union[float, sympy.Expr]
+    term: PauliTerm, time: Union[float, sympy.Expr]
 ) -> circuits.Circuit:
     """Evolves a Pauli term for a given time and returns a circuit representing it.
     Based on section 4 from https://arxiv.org/abs/1001.3855 .
@@ -62,19 +60,17 @@ def time_evolution_for_term(
 
     if len(term.terms) != 1:
         raise ValueError("This function works only on a single term.")
-    term_components = list(term.terms.keys())[0]
     base_changes = []
     base_reversals = []
     cnot_gates = []
     central_gate: Optional[circuits.GateOperation] = None
-    term_types = [component[1] for component in term_components]
-    qubit_indices = [component[0] for component in term_components]
-    coefficient = list(term.terms.values())[0]
+    term_types = list(term._ops.values())
+    qubit_indices = list(term._ops.keys())
 
     circuit = circuits.Circuit()
 
     # If constant term, return empty circuit.
-    if not term_components:
+    if term.is_constant:
         return circuit
 
     for i, (term_type, qubit_id) in enumerate(zip(term_types, qubit_indices)):
@@ -84,8 +80,8 @@ def time_evolution_for_term(
         elif term_type == "Y":
             base_changes.append(RX(np.pi / 2)(qubit_id))
             base_reversals.append(RX(-np.pi / 2)(qubit_id))
-        if i == len(term_components) - 1:
-            central_gate = RZ(2 * time * coefficient)(qubit_id)
+        if i == len(term._ops) - 1:
+            central_gate = RZ(2 * time * term.coefficient)(qubit_id)
         else:
             cnot_gates.append(CNOT(qubit_id, qubit_indices[i + 1]))
 
@@ -108,7 +104,7 @@ def time_evolution_for_term(
 
 
 def time_evolution_derivatives(
-    hamiltonian: QubitOperator,
+    hamiltonian: PauliRepresentation,
     time: float,
     method: str = "Trotter",
     trotter_order: int = 1,
@@ -132,17 +128,14 @@ def time_evolution_derivatives(
     single_trotter_derivatives = []
     factors = [1.0, -1.0]
     output_factors = []
-    terms: Iterable = list(hamiltonian.get_operators())
+    terms = hamiltonian.terms
 
     for i, term_1 in enumerate(terms):
         for factor in factors:
             output = circuits.Circuit()
 
             try:
-                if isinstance(term_1, QubitOperator):
-                    r = list(term_1.terms.values())[0] / trotter_order
-                else:
-                    r = complex(term_1.coefficient).real / trotter_order
+                r = complex(term_1.coefficient) / trotter_order
             except TypeError:
                 raise ValueError(
                     "Term coefficients need to be numerical. "

--- a/src/orquestra/quantum/evolution.py
+++ b/src/orquestra/quantum/evolution.py
@@ -3,6 +3,7 @@
 ################################################################################
 """Functions for constructing circuits simulating evolution under given Hamiltonian."""
 import operator
+import warnings
 from functools import reduce
 from itertools import chain
 from typing import List, Optional, Tuple, Union
@@ -134,13 +135,12 @@ def time_evolution_derivatives(
         for factor in factors:
             output = circuits.Circuit()
 
-            try:
-                r = complex(term_1.coefficient) / trotter_order
-            except TypeError:
-                raise ValueError(
-                    "Term coefficients need to be numerical. "
-                    f"Offending term: {term_1}"
+            if term_1.coefficient.real != term_1.coefficient:
+                warnings.warn(
+                    "Only real coefficients are supported. The imaginary part of the "
+                    "term {} will be ignored.".format(term_1)
                 )
+            r = term_1.coefficient.real / trotter_order
             output_factors.append(r * factor)
             shift = factor * (np.pi / (4.0 * r))
 

--- a/src/orquestra/quantum/measurements/measurements.py
+++ b/src/orquestra/quantum/measurements/measurements.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import copy
 import json
 from collections import Counter
-from typing import Dict, Iterable, List, Optional, Sequence, TextIO, Tuple, Union, cast
+from typing import Dict, Iterable, List, Optional, Sequence, TextIO, Tuple
 
 import numpy as np
 
@@ -17,7 +17,7 @@ from orquestra.quantum.utils import (
     sample_from_probability_distribution,
 )
 
-from ..wip.operators import PauliSum
+from ..wip.operators import PauliRepresentation
 from .expectation_values import ExpectationValues
 from .parities import check_parity_of_vector
 
@@ -287,7 +287,7 @@ class Measurements:
         return MeasurementOutcomeDistribution(distribution)
 
     def get_expectation_values(
-        self, ising_operator: PauliSum, use_bessel_correction: bool = False
+        self, ising_operator: PauliRepresentation, use_bessel_correction: bool = False
     ) -> ExpectationValues:
         """Get the expectation values of an operator from the measurements.
 
@@ -326,7 +326,7 @@ class Measurements:
         for i, first_term in enumerate(ising_operator.terms):
             correlations[i, i] = first_term.coefficient**2
             for j in range(i):
-                second_term = ising_operator[j]
+                second_term = ising_operator.terms[j]
                 marked_qubits = first_term.qubits.symmetric_difference(
                     second_term.qubits
                 )

--- a/src/orquestra/quantum/openfermion/__init__.py
+++ b/src/orquestra/quantum/openfermion/__init__.py
@@ -134,7 +134,6 @@ from orquestra.quantum.openfermion.zapata_utils import (
     get_fermion_number_operator,
     get_diagonal_component,
     get_polynomial_tensor,
-    create_circuits_from_qubit_operator,
     get_ground_state_rdm_from_qubit_op,
     remove_inactive_orbitals,
     hf_rdm,

--- a/src/orquestra/quantum/openfermion/linalg/sparse_tools.py
+++ b/src/orquestra/quantum/openfermion/linalg/sparse_tools.py
@@ -172,7 +172,7 @@ def pauli_operator_sparse(qubit_operator: PauliRepresentation, n_qubits=None):
         tensor_factor = 0
         coefficient = qubit_term.coefficient
         sparse_operators = [coefficient]
-        for qubit_num, operator_str in qubit_term._ops.items():
+        for qubit_num, operator_str in qubit_term.operations:
 
             # Grow space for missing identity operators.
             if qubit_num > tensor_factor:

--- a/src/orquestra/quantum/openfermion/linalg/sparse_tools.py
+++ b/src/orquestra/quantum/openfermion/linalg/sparse_tools.py
@@ -21,7 +21,6 @@ import numpy.linalg
 import scipy
 import scipy.sparse
 import scipy.sparse.linalg
-from sympy import Q
 
 from orquestra.quantum.openfermion.ops.operators import FermionOperator, QubitOperator
 from orquestra.quantum.openfermion.ops.representations import PolynomialTensor

--- a/src/orquestra/quantum/openfermion/zapata_utils/__init__.py
+++ b/src/orquestra/quantum/openfermion/zapata_utils/__init__.py
@@ -26,7 +26,6 @@ from ._io import (  # noqa: F403
 )
 from ._utils import (  # noqa: F403
     change_operator_type,
-    create_circuits_from_qubit_operator,
     evaluate_qubit_operator,
     evaluate_qubit_operator_list,
     generate_random_qubitop,

--- a/src/orquestra/quantum/openfermion/zapata_utils/_utils.py
+++ b/src/orquestra/quantum/openfermion/zapata_utils/_utils.py
@@ -7,7 +7,6 @@ from typing import Iterable, List, Optional
 
 import numpy as np
 
-from orquestra.quantum.circuits import Circuit, X, Y, Z
 from orquestra.quantum.measurements import ExpectationValues
 from orquestra.quantum.openfermion import (
     FermionOperator,
@@ -534,34 +533,6 @@ def get_polynomial_tensor(fermion_operator, n_qubits=None):
             tensor_dict[key][indices] = coefficient
 
     return PolynomialTensor(tensor_dict)
-
-
-def create_circuits_from_qubit_operator(
-    qubit_operator: PauliRepresentation,
-) -> List[Circuit]:
-    """Creates a list of circuit objects from a PauliTerm or PauliSum
-    Args:
-        qubit_operator: operator for which the Pauli terms are converted into circuits
-
-    Return:
-        circuit_set: a list of Pauli string gate circuits
-    """
-
-    term_gate_map = {"X": X, "Y": Y, "Z": Z}
-    circuit_set = []
-
-    # Loop over Pauli terms and populate circuit set list
-    for term in qubit_operator.terms:
-        circuit = Circuit()
-
-        # Loop over pauli operators in an n qubit pauli term and construct Pauli term
-        # circuit. Ignore coefficients.
-        for pauli_index, pauli_factor in term._ops.items():
-            circuit += term_gate_map[pauli_factor](pauli_index)
-
-        circuit_set += [circuit]
-
-    return circuit_set
 
 
 def get_ground_state_rdm_from_qubit_op(

--- a/src/orquestra/quantum/openfermion/zapata_utils/_utils.py
+++ b/src/orquestra/quantum/openfermion/zapata_utils/_utils.py
@@ -298,7 +298,7 @@ def reverse_qubit_order(
 
     for term in qubit_operator.terms:
         new_term = {}
-        for qubit_num, operator_str in term._ops.items():
+        for qubit_num, operator_str in term.operations:
             new_qubit_num = n_qubits - 1 - qubit_num
             new_term[new_qubit_num] = operator_str
         reversed_op += PauliTerm(new_term, term.coefficient)

--- a/src/orquestra/quantum/openfermion/zapata_utils/_utils.py
+++ b/src/orquestra/quantum/openfermion/zapata_utils/_utils.py
@@ -274,17 +274,19 @@ def evaluate_qubit_operator_list(
     return value_estimate
 
 
-def reverse_qubit_order(qubit_operator: PauliSum, n_qubits: Optional[int] = None):
+def reverse_qubit_order(
+    qubit_operator: PauliRepresentation, n_qubits: Optional[int] = None
+):
     """Reverse the order of qubit indices in a qubit operator.
 
     Args:
-        qubit_operator (openfermion.QubitOperator): the operator
+        qubit_operator: the operator to be reversed
         n_qubits (int): total number of qubits. Needs to be provided when
             the size of the system of interest is greater than the size of qubit
             operator (optional)
 
     Returns:
-        reversed_op (openfermion.ops.QubitOperator)
+        reversed_op: the reversed operator
     """
 
     reversed_op = PauliSum()
@@ -534,8 +536,10 @@ def get_polynomial_tensor(fermion_operator, n_qubits=None):
     return PolynomialTensor(tensor_dict)
 
 
-def create_circuits_from_qubit_operator(qubit_operator: QubitOperator) -> List[Circuit]:
-    """Creates a list of circuit objects from the Pauli terms of a QubitOperator
+def create_circuits_from_qubit_operator(
+    qubit_operator: PauliRepresentation,
+) -> List[Circuit]:
+    """Creates a list of circuit objects from a PauliTerm or PauliSum
     Args:
         qubit_operator: operator for which the Pauli terms are converted into circuits
 
@@ -543,20 +547,16 @@ def create_circuits_from_qubit_operator(qubit_operator: QubitOperator) -> List[C
         circuit_set: a list of Pauli string gate circuits
     """
 
-    # Get the Pauli terms, ignoring coefficients
-    pauli_terms = list(qubit_operator.terms.keys())
     term_gate_map = {"X": X, "Y": Y, "Z": Z}
     circuit_set = []
 
     # Loop over Pauli terms and populate circuit set list
-    for term in pauli_terms:
-
+    for term in qubit_operator.terms:
         circuit = Circuit()
 
-        # Loop over Pauli factors in Pauli term and construct Pauli term circuit
-        for pauli in term:  # loop over pauli operators in an n qubit pauli term
-            pauli_index = pauli[0]
-            pauli_factor = pauli[1]
+        # Loop over pauli operators in an n qubit pauli term and construct Pauli term
+        # circuit. Ignore coefficients.
+        for pauli_index, pauli_factor in term._ops.items():
             circuit += term_gate_map[pauli_factor](pauli_index)
 
         circuit_set += [circuit]

--- a/src/orquestra/quantum/testing/test_cases_for_backend_tests.py
+++ b/src/orquestra/quantum/testing/test_cases_for_backend_tests.py
@@ -170,7 +170,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "I"],
         "CNOT",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -183,7 +183,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "H"],
         "CNOT",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -196,7 +196,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["H", "I"],
         "CNOT",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             1,
@@ -209,7 +209,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["H", "H"],
         "CNOT",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             1,
@@ -222,7 +222,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "I"],
         "SWAP",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -235,7 +235,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "H"],
         "SWAP",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -248,7 +248,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["H", "I"],
         "SWAP",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -261,7 +261,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["H", "H"],
         "SWAP",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             1,
@@ -274,7 +274,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "I"],
         "ISWAP",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -287,7 +287,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "H"],
         "ISWAP",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -300,7 +300,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["H", "I"],
         "ISWAP",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -313,7 +313,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["H", "H"],
         "ISWAP",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -326,7 +326,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "I"],
         "CZ",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -339,7 +339,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "H"],
         "CZ",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -352,7 +352,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["H", "I"],
         "CZ",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -365,7 +365,7 @@ two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["H", "H"],
         "CZ",
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -382,7 +382,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "CPHASE",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -396,7 +396,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "CPHASE",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -410,7 +410,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "CPHASE",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -424,7 +424,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "CPHASE",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -438,7 +438,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "CPHASE",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -452,7 +452,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "CPHASE",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -466,7 +466,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "CPHASE",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -480,7 +480,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "CPHASE",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -494,7 +494,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "CPHASE",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -508,7 +508,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "CPHASE",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -522,7 +522,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "CPHASE",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -536,7 +536,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "CPHASE",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -550,7 +550,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "CPHASE",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -564,7 +564,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "CPHASE",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -578,7 +578,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "CPHASE",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -592,7 +592,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "CPHASE",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1 / 2,
@@ -606,7 +606,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "CPHASE",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             1,
@@ -620,7 +620,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "CPHASE",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             np.sqrt(5) / 8 + 5 / 8,
@@ -634,7 +634,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "CPHASE",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1 / 2,
@@ -648,7 +648,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "CPHASE",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -662,7 +662,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XX",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -676,7 +676,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XX",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -690,7 +690,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XX",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -704,7 +704,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XX",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -718,7 +718,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XX",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -732,7 +732,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XX",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -746,7 +746,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XX",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -760,7 +760,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XX",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -774,7 +774,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XX",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -788,7 +788,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XX",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -802,7 +802,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XX",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -816,7 +816,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XX",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -830,7 +830,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XX",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -844,7 +844,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XX",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -858,7 +858,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XX",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -872,7 +872,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XX",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -886,7 +886,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XX",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             1,
@@ -900,7 +900,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XX",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -914,7 +914,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XX",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -928,7 +928,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XX",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -942,7 +942,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "YY",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -956,7 +956,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "YY",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -970,7 +970,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "YY",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -984,7 +984,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "YY",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -998,7 +998,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "YY",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1012,7 +1012,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "YY",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1026,7 +1026,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "YY",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1040,7 +1040,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "YY",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1054,7 +1054,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "YY",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1068,7 +1068,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "YY",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1082,7 +1082,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "YY",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1096,7 +1096,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "YY",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1110,7 +1110,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "YY",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1124,7 +1124,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "YY",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1138,7 +1138,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "YY",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1152,7 +1152,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "YY",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1166,7 +1166,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "YY",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             1,
@@ -1180,7 +1180,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "YY",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1194,7 +1194,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "YY",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1208,7 +1208,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "YY",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1222,7 +1222,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "ZZ",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1236,7 +1236,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "ZZ",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1250,7 +1250,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "ZZ",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1264,7 +1264,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "ZZ",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1278,7 +1278,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "ZZ",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1292,7 +1292,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "ZZ",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1306,7 +1306,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "ZZ",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1320,7 +1320,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "ZZ",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1334,7 +1334,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "ZZ",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1348,7 +1348,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "ZZ",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1362,7 +1362,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "ZZ",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1376,7 +1376,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "ZZ",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1390,7 +1390,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "ZZ",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1404,7 +1404,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "ZZ",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1418,7 +1418,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "ZZ",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1432,7 +1432,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "ZZ",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1446,7 +1446,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "ZZ",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             1,
@@ -1460,7 +1460,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "ZZ",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1474,7 +1474,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "ZZ",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1488,7 +1488,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "ZZ",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1502,7 +1502,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XY",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1516,7 +1516,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XY",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1530,7 +1530,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XY",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1544,7 +1544,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XY",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1558,7 +1558,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "I"],
         "XY",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1572,7 +1572,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XY",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1586,7 +1586,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XY",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1600,7 +1600,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XY",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1614,7 +1614,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XY",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1628,7 +1628,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["I", "H"],
         "XY",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1642,7 +1642,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XY",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1656,7 +1656,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XY",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             0,
@@ -1670,7 +1670,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XY",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1684,7 +1684,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XY",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1698,7 +1698,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "I"],
         "XY",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             0,
@@ -1712,7 +1712,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XY",
         [-np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1726,7 +1726,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XY",
         [0],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1,
             1,
@@ -1740,7 +1740,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XY",
         [np.pi / 5],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1754,7 +1754,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XY",
         [np.pi / 2],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,
@@ -1768,7 +1768,7 @@ two_qubit_parametric_gates_exp_vals_test_set = [
         ["H", "H"],
         "XY",
         [np.pi],
-        ["[]", "[X0 X1]", "[Y0 Y1]", "[Z0 Z1]", "[X1]", "[Z0]"],
+        ["I0", "X0*X1", "Y0*Y1", "Z0*Z1", "X1", "Z0"],
         [
             1.00000000000000,
             1.00000000000000,

--- a/src/orquestra/quantum/wip/operators/_pauli_operators.py
+++ b/src/orquestra/quantum/wip/operators/_pauli_operators.py
@@ -215,7 +215,7 @@ class PauliTerm:
         (i.e. contains only Z terms or is an identity term)
         """
 
-        return set(self._ops.values()) == {"Z"} or set(self._ops.values()) == set()
+        return set(self._ops.values()) == {"Z"} or self.is_constant
 
     @property
     def circuit(self) -> Circuit:

--- a/src/orquestra/quantum/wip/operators/_pauli_operators.py
+++ b/src/orquestra/quantum/wip/operators/_pauli_operators.py
@@ -238,7 +238,8 @@ class PauliTerm:
 
         return self._circuit
 
-    def operations_as_set(self) -> FrozenSet[Tuple[int, str]]:
+    @property
+    def operations(self) -> FrozenSet[Tuple[int, str]]:
         return frozenset(self._ops.items())
 
     def __len__(self) -> int:
@@ -260,7 +261,7 @@ class PauliTerm:
             (
                 round(self.coefficient.real * HASH_PRECISION),
                 round(self.coefficient.imag * HASH_PRECISION),
-                self.operations_as_set(),
+                self.operations,
             )
         )
 
@@ -275,9 +276,8 @@ class PauliTerm:
             return other == self
 
         cast_other = cast(PauliTerm, other)
-        return (
-            self.operations_as_set() == cast_other.operations_as_set()
-            and np.allclose(self.coefficient, cast_other.coefficient)
+        return self.operations == cast_other.operations and np.allclose(
+            self.coefficient, cast_other.coefficient
         )
 
     def __add__(self, other: Union[PauliRepresentation, complex]) -> "PauliSum":
@@ -503,7 +503,7 @@ class PauliSum:
     def simplify(self) -> "PauliSum":
         like_terms: Dict[Hashable, List[PauliTerm]] = OrderedDict()
         for term in self.terms:
-            key = term.operations_as_set()
+            key = term.operations
             if key in like_terms:
                 like_terms[key].append(term)
             else:

--- a/tests/orquestra/quantum/evolution_test.py
+++ b/tests/orquestra/quantum/evolution_test.py
@@ -14,10 +14,10 @@ from orquestra.quantum.evolution import (
     time_evolution_derivatives,
     time_evolution_for_term,
 )
-from orquestra.quantum.openfermion import QubitOperator
 from orquestra.quantum.utils import compare_unitary
+from orquestra.quantum.wip.operators import PauliRepresentation, PauliSum, PauliTerm
 
-OPENFERMION_TERM_TO_ORQUESTRA_GATE = {
+TUPLE_TERM_TO_ORQUESTRA_GATE = {
     ((0, "X"), (1, "X")): XX,
     ((0, "Y"), (1, "Y")): YY,
     ((0, "Z"), (1, "Z")): ZZ,
@@ -26,12 +26,15 @@ OPENFERMION_TERM_TO_ORQUESTRA_GATE = {
 
 def _orquestra_exponentiate_qubit_hamiltonian_term(term, time, trotter_order):
     base_exponent = 2 * time / trotter_order / np.pi
-    coefficient = list(term.terms.values())[0]
 
-    base_gate = OPENFERMION_TERM_TO_ORQUESTRA_GATE[list(term.terms.keys())[0]]
+    base_gate = TUPLE_TERM_TO_ORQUESTRA_GATE[tuple(term._ops.items())]
     # This introduces a phase to the gate, but that's fine
     # since `compare_unitary` accounts for that
     mat = base_gate(np.pi)(0, 1).lifted_matrix(2)
+    if term.coefficient.real == term.coefficient:
+        coefficient = term.coefficient.real
+    else:
+        raise ValueError("Cannot raise matrix to the power of a complex coefficinet")
     zquant_mat = fractional_matrix_power(mat, coefficient * base_exponent)
 
     return zquant_mat
@@ -39,7 +42,7 @@ def _orquestra_exponentiate_qubit_hamiltonian_term(term, time, trotter_order):
 
 def _orquestra_exponentiate_hamiltonian(hamiltonian, time, trotter_order):
     ops = []
-    for term in hamiltonian.get_operators():
+    for term in hamiltonian.terms:
         mat = _orquestra_exponentiate_qubit_hamiltonian_term(term, time, trotter_order)
         ops.append(
             circuits.CustomGateDefinition(
@@ -57,13 +60,13 @@ def _orquestra_exponentiate_hamiltonian(hamiltonian, time, trotter_order):
 @pytest.mark.parametrize(
     "term, time, expected_unitary",
     [
-        (QubitOperator("[X0 X1]"), np.pi, -np.eye(4)),
+        (PauliTerm("X0*X1"), np.pi, -np.eye(4)),
         (
-            QubitOperator("0.5 [Y0 Y1]"),
+            PauliTerm("0.5*Y0*Y1"),
             np.pi,
             np.diag([1j, -1j, -1j, 1j])[::-1],
         ),
-        (QubitOperator("[Z0 Z1]"), np.pi, -np.eye(4)),
+        (PauliTerm("Z0*Z1"), np.pi, -np.eye(4)),
     ],
 )
 class TestTimeEvolutionOfTerm:
@@ -88,14 +91,14 @@ class TestTimeEvolutionOfConstantTerm:
     # This test is added to make sure that constant terms in qubit operators
     # do not cause errors.
     def test_evolving_constant_term_qubit_operator_gives_empty_circuit(self):
-        evolution_circuit = time_evolution_for_term(QubitOperator((), 1), np.pi)
+        evolution_circuit = time_evolution_for_term(PauliTerm.identity() * 3, np.pi)
         assert evolution_circuit == circuits.Circuit()
 
 
 class TestTimeEvolutionOfPauliSum:
     @pytest.fixture
     def hamiltonian(self):
-        return QubitOperator("[X0 X1] + 0.5[Y0 Y1] + 0.3[Z0 Z1]")
+        return PauliSum("X0*X1 + 0.5*Y0*Y1 + 0.3*Z0*Z1")
 
     @pytest.mark.parametrize("time", [0.1, 0.4, 1.0])
     @pytest.mark.parametrize("order", [1, 2, 3])
@@ -200,7 +203,7 @@ class TestGeneratingCircuitSequence:
 class TestTimeEvolutionDerivatives:
     @pytest.fixture
     def hamiltonian(self):
-        return QubitOperator("[X0 X1] + 0.5[Y0 Y1] + 0.3[Z0 Z1]")
+        return PauliSum("X0*X1 + 0.5*Y0*Y1 + 0.3*Z0*Z1")
 
     @pytest.mark.parametrize("time", [0.4, sympy.Symbol("t")])
     def test_gives_correct_number_of_derivatives_and_factors(self, time, hamiltonian):

--- a/tests/orquestra/quantum/openfermion/zapata_utils/_utils_test.py
+++ b/tests/orquestra/quantum/openfermion/zapata_utils/_utils_test.py
@@ -255,7 +255,7 @@ class TestQubitOperator(unittest.TestCase):
         circuit2 = Circuit([Y(0), Z(1)])
 
         # Given
-        qubit_op = QubitOperator("Z0 X1") + QubitOperator("Y0 Z1")
+        qubit_op = PauliTerm("Z0*X1") + PauliTerm("Y0*Z1")
 
         # When
         pauli_circuits = create_circuits_from_qubit_operator(qubit_op)

--- a/tests/orquestra/quantum/openfermion/zapata_utils/_utils_test.py
+++ b/tests/orquestra/quantum/openfermion/zapata_utils/_utils_test.py
@@ -8,7 +8,6 @@ import numpy as np
 import pkg_resources
 import pytest
 
-from orquestra.quantum.circuits import Circuit, X, Y, Z
 from orquestra.quantum.measurements import ExpectationValues
 from orquestra.quantum.openfermion.hamiltonians import fermi_hubbard
 from orquestra.quantum.openfermion.linalg import (
@@ -244,25 +243,6 @@ class TestQubitOperator(unittest.TestCase):
 
         # Then
         self.assertEqual(number_operator, correct_operator)
-
-    def test_create_circuits_from_qubit_operator(self):
-        from orquestra.quantum.openfermion.zapata_utils._utils import (
-            create_circuits_from_qubit_operator,
-        )
-
-        # Initialize target
-        circuit1 = Circuit([Z(0), X(1)])
-        circuit2 = Circuit([Y(0), Z(1)])
-
-        # Given
-        qubit_op = PauliTerm("Z0*X1") + PauliTerm("Y0*Z1")
-
-        # When
-        pauli_circuits = create_circuits_from_qubit_operator(qubit_op)
-
-        # Then
-        self.assertEqual(pauli_circuits[0], circuit1)
-        self.assertEqual(pauli_circuits[1], circuit2)
 
 
 class TestOtherUtils(unittest.TestCase):

--- a/tests/orquestra/quantum/wip/operators/_operators_test.py
+++ b/tests/orquestra/quantum/wip/operators/_operators_test.py
@@ -26,7 +26,7 @@ class TestPauliTermInitialization:
     )
     def test_term_can_be_initialized_with_dictionary(self, operator_dict, coefficient):
         term = PauliTerm(operator_dict, coefficient)
-        assert term.operations_as_set() == frozenset(operator_dict.items())
+        assert term.operations == frozenset(operator_dict.items())
         assert term.coefficient == coefficient
         assert term.qubits == frozenset(operator_dict)
 
@@ -44,7 +44,7 @@ class TestPauliTermInitialization:
         self, pauli_str, coefficient, qubit_index, operator
     ):
         term = PauliTerm(pauli_str, coefficient)
-        assert term.operations_as_set() == frozenset([(qubit_index, operator)])
+        assert term.operations == frozenset([(qubit_index, operator)])
         assert term.coefficient == coefficient
         assert term.qubits == {qubit_index}
 
@@ -59,7 +59,7 @@ class TestPauliTermInitialization:
         self, pauli_str, coefficient, qubit_indices, operators
     ):
         term = PauliTerm(pauli_str, coefficient)
-        assert term.operations_as_set() == frozenset(zip(qubit_indices, operators))
+        assert term.operations == frozenset(zip(qubit_indices, operators))
         assert term.coefficient == coefficient
         assert term.qubits == frozenset(qubit_indices)
 
@@ -76,7 +76,7 @@ class TestPauliTermInitialization:
         self, pauli_str, coefficient, qubit_indices, operators
     ):
         term = PauliTerm(pauli_str)
-        assert term.operations_as_set() == frozenset(zip(qubit_indices, operators))
+        assert term.operations == frozenset(zip(qubit_indices, operators))
         assert term.coefficient == coefficient
         assert term.qubits == frozenset(qubit_indices)
 
@@ -96,7 +96,7 @@ class TestPauliTermInitialization:
         ],
     )
     def test_identity_operators_are_not_stored_in_iterm(self, pauli_str, expected_ops):
-        assert PauliTerm(pauli_str).operations_as_set() == frozenset(expected_ops)
+        assert PauliTerm(pauli_str).operations == frozenset(expected_ops)
 
     @pytest.mark.parametrize(
         "pauli_str", ["1 X", "X - 1254", "A0", "5.0 + Z1", "0.3+0.5j * X0", "X0 Z1"]
@@ -159,7 +159,7 @@ class TestConstructingPauliTermFromList:
         # The reverse (pair[::-1]) is from the fact, that for whatever reason
         # from_list accepts input in the reverse direction then the
         # operations_as_set produces it.
-        assert term.operations_as_set() == frozenset([pair[::-1] for pair in op_list])
+        assert term.operations == frozenset([pair[::-1] for pair in op_list])
         assert term.coefficient == coefficient
 
     def test_term_cannot_be_constructed_from_list_of_incorrectly_shaped_tuples(self):


### PR DESCRIPTION
## Description

Use the new pauli operator data structures instead of openfermion. Follow-up to #41. This PR removes all usage of QubitOperator and IsingOperator in this repo outside of the `openfermion` directory.

Merge after https://github.com/zapatacomputing/orquestra-quantum/pull/44

Note that `QuantumBackendGatesTests` is not used in any orquestra repository, so I wasn't able to run tests to make sure that my changes work. (I do wonder if we need this class if it's not used anywhere?)

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
