### PR TITLE
fix: getting sparse matrix from pauli operators sometimes fails

### DIFF
--- a/src/orquestra/quantum/openfermion/linalg/sparse_tools.py
+++ b/src/orquestra/quantum/openfermion/linalg/sparse_tools.py
@@ -172,7 +172,7 @@ def pauli_operator_sparse(qubit_operator: PauliRepresentation, n_qubits=None):
         tensor_factor = 0
         coefficient = qubit_term.coefficient
         sparse_operators = [coefficient]
-        for qubit_num, operator_str in qubit_term.operations:
+        for qubit_num, operator_str in sorted(qubit_term.operations):
 
             # Grow space for missing identity operators.
             if qubit_num > tensor_factor:

--- a/tests/orquestra/quantum/openfermion/linalg/sparse_tools_test.py
+++ b/tests/orquestra/quantum/openfermion/linalg/sparse_tools_test.py
@@ -174,6 +174,13 @@ class JordanWignerSparseTest(unittest.TestCase):
             )
         )
 
+    def test_pauli_operator_sparse_with_different_qubit_order(self):
+        op = PauliTerm("(2+0j)*Z0*Z3")
+        op2 = PauliTerm("(2+0j)*Z3*Z0")
+        self.assertTrue(
+            numpy.allclose(pauli_operator_sparse(op).A, pauli_operator_sparse(op2).A)
+        )
+
 
 class ComputationalBasisStateTest(unittest.TestCase):
     def test_computational_basis_state(self):


### PR DESCRIPTION
## Description

small fix, was causing tests in https://github.com/zapatacomputing/orquestra-vqa/pull/21 to fail

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
