### PR TITLE
(fix): PauliTerm.from_iterable throws error with empty list

### DIFF
--- a/src/orquestra/quantum/operators/_pauli_operators.py
+++ b/src/orquestra/quantum/operators/_pauli_operators.py
@@ -179,19 +179,20 @@ class PauliTerm:
         """
 
         ############### Some checks on input first ###############
-        _, idx_list = zip(*terms)
+        if len(terms) > 0:
+            _, idx_list = zip(*terms)
 
-        if not all([isinstance(op, tuple) for op in terms]):
-            raise ValueError(
-                "The list can only contain tuples of the form (index, op). If you "
-                "want to initialize from strings, use PauliTerm's constructor."
-            )
+            if not all([isinstance(op, tuple) for op in terms]):
+                raise ValueError(
+                    "The list can only contain tuples of the form (index, op). If you "
+                    "want to initialize from strings, use PauliTerm's constructor."
+                )
 
-        if len(set(idx_list)) != len(idx_list):
-            raise ValueError(
-                "Duplicate indices used in list. Manually create terms"
-                "and multiply them instead."
-            )
+            if len(set(idx_list)) != len(idx_list):
+                raise ValueError(
+                    "Duplicate indices used in list. Manually create terms"
+                    "and multiply them instead."
+                )
 
         ##########################################################
 

--- a/src/orquestra/quantum/operators/_pauli_operators.py
+++ b/src/orquestra/quantum/operators/_pauli_operators.py
@@ -179,7 +179,7 @@ class PauliTerm:
         """
 
         ############### Some checks on input first ###############
-        if len(terms) > 0:
+        if terms:
             _, idx_list = zip(*terms)
 
             if not all([isinstance(op, tuple) for op in terms]):

--- a/tests/orquestra/quantum/operators/_operators_test.py
+++ b/tests/orquestra/quantum/operators/_operators_test.py
@@ -162,6 +162,17 @@ class TestConstructingPauliTermFromIterable:
         assert term.operations == frozenset([pair[::-1] for pair in ops])
         assert term.coefficient == coefficient
 
+    def test_identity_term_is_constructed_from_empty_iterable(self):
+        term = PauliTerm.from_iterable([])
+        assert term.operations == frozenset()
+        assert term.coefficient == 1.0
+        assert term == PauliTerm.identity()
+
+        term_with_coeff = PauliTerm.from_iterable([], 2.0 + 3.0j)
+        assert term_with_coeff.operations == frozenset()
+        assert term_with_coeff.coefficient == 2.0 + 3.0j
+        assert term_with_coeff == PauliTerm.identity() * (2.0 + 3.0j)
+
     def test_term_cannot_be_constructed_from_iterable_of_incorrectly_shaped_tuples(
         self,
     ):


### PR DESCRIPTION
## Description

Small bugfix needed for some functions loading pauli terms from dictionaries

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
