### PR TITLE
use .copy method to create new terms

### DIFF
--- a/src/orquestra/quantum/operators/_openfermion_utils/operator_utils.py
+++ b/src/orquestra/quantum/operators/_openfermion_utils/operator_utils.py
@@ -27,11 +27,11 @@ def hermitian_conjugated(operator):
     if isinstance(operator, PauliSum):
         conjugate_operator = PauliSum()
         for term in operator.terms:
-            conjugate_operator += PauliTerm(term._ops, term.coefficient.conjugate())
+            conjugate_operator += term.copy(term.coefficient.conjugate())
 
     # Handle PauliTerm
     elif isinstance(operator, PauliTerm):
-        conjugate_operator = PauliTerm(operator._ops, operator.coefficient.conjugate())
+        conjugate_operator = operator.copy(operator.coefficient.conjugate())
 
     # Handle sparse matrix
     elif isinstance(operator, spmatrix):


### PR DESCRIPTION
## Description

So we use PauliTerm api like intended rather than accessing the private `._ops` property.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
