### PR TITLE
Bugfix complex trotterization

### DIFF
--- a/src/orquestra/quantum/evolution.py
+++ b/src/orquestra/quantum/evolution.py
@@ -71,6 +71,9 @@ def time_evolution_for_term(
     if term.is_constant:
         return circuit
 
+    if term.coefficient.imag > 1e-9:
+        raise ValueError("Coefficients of terms must be real for Trotterization.")
+
     for i, qubit_id in enumerate(qubit_indices):
         term_type = term[qubit_id]
         if term_type == "X":
@@ -80,7 +83,7 @@ def time_evolution_for_term(
             base_changes.append(RX(np.pi / 2)(qubit_id))
             base_reversals.append(RX(-np.pi / 2)(qubit_id))
         if i == len(term.operations) - 1:
-            central_gate = RZ(2 * time * term.coefficient)(qubit_id)
+            central_gate = RZ(2 * time * term.coefficient.real)(qubit_id)
         else:
             cnot_gates.append(CNOT(qubit_id, qubit_indices[i + 1]))
 

--- a/tests/orquestra/quantum/distributions/_measurement_outcome_distribution_test.py
+++ b/tests/orquestra/quantum/distributions/_measurement_outcome_distribution_test.py
@@ -3,6 +3,7 @@
 ################################################################################
 import json
 import math
+import warnings
 from io import StringIO
 from itertools import product
 from sys import float_info
@@ -424,42 +425,40 @@ class TestSubdistribution:
         [
             (
                 MeasurementOutcomeDistribution(
-                    {"001": 100, "010": 101, "011": 7}, normalize=False
+                    {"001": 0.5, "010": 0.3, "011": 0.2},
                 ),
                 [0, 1, 2],
-                {(0, 0, 1): 100, (0, 1, 0): 101, (0, 1, 1): 7},
+                {(0, 0, 1): 0.5, (0, 1, 0): 0.3, (0, 1, 1): 0.2},
             ),
             (
-                MeasurementOutcomeDistribution(
-                    {"001": 50, "010": 45, "011": 5}, normalize=True
-                ),
+                MeasurementOutcomeDistribution({"001": 50, "010": 45, "011": 5}),
                 [0, 2],
                 {(0, 1): 0.55, (0, 0): 0.45},
             ),
             (
                 MeasurementOutcomeDistribution(
-                    {"001": 100, "010": 101, "011": 7}, normalize=False
+                    {"001": 0.5, "010": 0.3, "011": 0.2},
                 ),
                 [1, 0, 2],
-                {(0, 0, 1): 100, (1, 0, 0): 101, (1, 0, 1): 7},
+                {(0, 0, 1): 0.5, (1, 0, 0): 0.3, (1, 0, 1): 0.2},
             ),
             (
                 MeasurementOutcomeDistribution(
-                    {(0, 0, 1): 100, (0, 1, 0): 101, (0, 1, 1): 7}, normalize=False
+                    {"001": 0.5, "010": 0.3, "011": 0.2},
                 ),
                 [1, 0],
-                {(0, 0): 100, (1, 0): 108},
+                {(0, 0): 0.5, (1, 0): 0.5},
             ),
             (
                 MeasurementOutcomeDistribution(
-                    {"001": 100, "010": 101, "011": 7}, normalize=False
+                    {"001": 0.5, "010": 0.3, "011": 0.2},
                 ),
                 [2, 1, 0],
-                {(1, 0, 0): 100, (0, 1, 0): 101, (1, 1, 0): 7},
+                {(1, 0, 0): 0.5, (0, 1, 0): 0.3, (1, 1, 0): 0.2},
             ),
         ],
     )
-    def test_if_subdistribution_works(
+    def test_simple_subdistributions(
         self, input_distribution, active_qubits, target_dict
     ):
         assert (

--- a/tests/orquestra/quantum/evolution_test.py
+++ b/tests/orquestra/quantum/evolution_test.py
@@ -87,6 +87,11 @@ class TestTimeEvolutionOfTerm:
         np.testing.assert_array_almost_equal(actual_unitary, expected_unitary)
 
 
+def test_complex_coefficent_throws_error():
+    with pytest.raises(ValueError):
+        time_evolution_for_term(PauliTerm("X0", 1j), 1)
+
+
 class TestTimeEvolutionOfConstantTerm:
     # This test is added to make sure that constant terms in qubit operators
     # do not cause errors.


### PR DESCRIPTION
## Description

@KaterinaGratsea found that circuits generated from trotterization cannot be exported to qiskit as they input complex parameters to the RZ gate.

This PR ensures that the coefficient of the trotterized hamiltonian is real and takes the real part of the complex coefficient to ensure that the generated circuit can be converted to a qiskit circuit. 

I also took a second to remove unnecessary warnings from our tests. Nice and green now. 😄 


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
