### PR TITLE
fix: custom gate definition not working with ControlledGate

### DIFF
--- a/src/orquestra/quantum/circuits/_circuit.py
+++ b/src/orquestra/quantum/circuits/_circuit.py
@@ -26,6 +26,10 @@ def _circuit_size_by_operations(operations):
 
 
 def _operation_uses_custom_gate(operation):
+    if isinstance(operation.gate, _gates.ControllerGate):
+        return isinstance(operation.gate.wrapped_gate, _gates.MatrixFactoryGate) and isinstance(
+            operation.gate.wrapped_gate.matrix_factory, _gates.CustomGateMatrixFactory
+        )
     return isinstance(operation.gate, _gates.MatrixFactoryGate) and isinstance(
         operation.gate.matrix_factory, _gates.CustomGateMatrixFactory
     )

--- a/tests/orquestra/quantum/circuits/_circuit_test.py
+++ b/tests/orquestra/quantum/circuits/_circuit_test.py
@@ -270,3 +270,21 @@ class TestCircuitInverse:
         circuit = Circuit(operations=[gate])
         with pytest.raises(AttributeError):
             circuit.inverse()
+
+class TestCustomGateCircuit:
+    def test_custom_gate_wrapped_by_controller_gate_circuit(self):
+        g = CustomGateDefinition("P'",
+            sympy.Matrix(
+                [
+                    [-1, 0],
+                    [0, 1],
+                ]
+            ), ())()
+        controlled_qubits = (1,1)
+        c_op = g.controlled(1)(*controlled_qubits)
+        c = Circuit()
+        c += c_op 
+        assert len(c.collect_custom_gate_definitions()) > 0
+
+
+


### PR DESCRIPTION
## Description

With ControlledGate, the function collect_custom_gate_definitions() returns an empty list even if there is a custom gate wrapped by the ControlledGate. The internal function _operation_uses_custom_gate does not take into account ControlledGate and returns False in the current implementation.

This is a raised exception caught by the try except when running run_circuit_and_measure since the gate name is not in custom_names in _export_custom_gate which is called from _export_controlled_gate:
```ValueError: Can't export gate ControlledGate(wrapped_gate=MatrixFactoryGate(name="P'", matrix_factory=CustomGateMatrixFactory(gate_definition=CustomGateDefinition(gate_name="P'", matrix=Matrix([
[1, 0, 0, 0],
[0, 1, 0, 0],
[0, 0, 0, 1],
[0, 0, 1, 0]]), params_ordering=())), params=(), num_qubits=2, is_hermitian=False), num_control_qubits=1) as a custom gate, the circuit is missing its definition
```

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
