### PR TITLE
feat(wavefunction): cache ordering results

### DIFF
--- a/src/orquestra/quantum/operators/_pauli_operators.py
+++ b/src/orquestra/quantum/operators/_pauli_operators.py
@@ -35,7 +35,7 @@ from typing import (
 
 import numpy as np
 
-from orquestra.quantum.circuits import Circuit, Operation, builtin_gate_by_name
+from ..circuits import Circuit, Operation, builtin_gate_by_name
 
 PauliRepresentation = Union["PauliTerm", "PauliSum"]
 

--- a/src/orquestra/quantum/operators/_pauli_operators.py
+++ b/src/orquestra/quantum/operators/_pauli_operators.py
@@ -35,7 +35,7 @@ from typing import (
 
 import numpy as np
 
-from ..circuits import Circuit, Operation, builtin_gate_by_name
+from orquestra.quantum.circuits import Circuit, Operation, builtin_gate_by_name
 
 PauliRepresentation = Union["PauliTerm", "PauliSum"]
 
@@ -541,6 +541,9 @@ class PauliSum:
             zero_identity_term = PauliTerm("I0", 0)
             return str(zero_identity_term)
         return " + ".join([str(term) for term in self.terms])
+
+    def __hash__(self):
+        return hash(tuple(self.terms))
 
     @property
     def is_constant(self) -> bool:

--- a/src/orquestra/quantum/wavefunction.py
+++ b/src/orquestra/quantum/wavefunction.py
@@ -2,6 +2,7 @@
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
 import json
+from functools import lru_cache
 from math import log2
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 from warnings import warn
@@ -214,12 +215,16 @@ def flip_wavefunction(wavefunction: Wavefunction):
 
 
 def flip_amplitudes(amplitudes: Union[Sequence[complex], np.ndarray]) -> np.ndarray:
-    number_of_states = len(amplitudes)
-    ordering = [
+    ordering = _get_ordering(len(amplitudes))
+    return np.array([amplitudes[i] for i in ordering])
+
+
+@lru_cache(maxsize=8)
+def _get_ordering(number_of_states: int) -> List[int]:
+    return [
         _flip_bits(n, number_of_states.bit_length() - 1)
         for n in range(number_of_states)
     ]
-    return np.array([amplitudes[i] for i in ordering])
 
 
 def _flip_bits(n, num_bits):

--- a/src/orquestra/quantum/wavefunction.py
+++ b/src/orquestra/quantum/wavefunction.py
@@ -219,7 +219,7 @@ def flip_amplitudes(amplitudes: Union[Sequence[complex], np.ndarray]) -> np.ndar
     return np.array([amplitudes[i] for i in ordering])
 
 
-@lru_cache(maxsize=8)
+@lru_cache()
 def _get_ordering(number_of_states: int) -> List[int]:
     return [
         _flip_bits(n, number_of_states.bit_length() - 1)


### PR DESCRIPTION
## Description

Cache ordering from `_flip_bits` to prevent re-computing them.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
