### PR TITLE
Fast flip amplitudes

### DIFF
--- a/src/orquestra/quantum/wavefunction.py
+++ b/src/orquestra/quantum/wavefunction.py
@@ -221,6 +221,11 @@ def flip_wavefunction(wavefunction: Wavefunction):
 
 def flip_amplitudes(amplitudes: Union[Sequence[complex], np.ndarray]) -> np.ndarray:
     number_of_states = len(amplitudes)
+    ordering = _get_ordering(number_of_states)
+    return np.asarray(amplitudes)[ordering]
+
+@lru_cache
+def _get_ordering(number_of_states: int) -> np.ndarray:
     num_bits = number_of_states.bit_length() - 1
     ordering = (
         np.arange(2 ** num_bits)
@@ -228,10 +233,7 @@ def flip_amplitudes(amplitudes: Union[Sequence[complex], np.ndarray]) -> np.ndar
         .transpose(*reversed(range(num_bits)))
         .reshape(2 ** num_bits)
     )
-    if isinstance(amplitudes, np.ndarray):
-        return amplitudes[ordering]
-    else:
-        return np.array([amplitudes[i] for i in ordering])
+    return ordering
 
 
 def load_wavefunction(file: LoadSource) -> Wavefunction:

--- a/src/orquestra/quantum/wavefunction.py
+++ b/src/orquestra/quantum/wavefunction.py
@@ -220,20 +220,18 @@ def flip_wavefunction(wavefunction: Wavefunction):
 
 
 def flip_amplitudes(amplitudes: Union[Sequence[complex], np.ndarray]) -> np.ndarray:
-    ordering = _get_ordering(len(amplitudes))
-    return np.array([amplitudes[i] for i in ordering])
-
-
-@lru_cache()
-def _get_ordering(number_of_states: int) -> List[int]:
-    return [
-        _flip_bits(n, number_of_states.bit_length() - 1)
-        for n in range(number_of_states)
-    ]
-
-
-def _flip_bits(n, num_bits):
-    return int(bin(n)[2:].zfill(num_bits)[::-1], 2)
+    number_of_states = len(amplitudes)
+    num_bits = number_of_states.bit_length() - 1
+    ordering = (
+        np.arange(2 ** num_bits)
+        .reshape(num_bits * [2])
+        .transpose(*reversed(range(num_bits)))
+        .reshape(2 ** num_bits)
+    )
+    if isinstance(amplitudes, np.ndarray):
+        return amplitudes[ordering]
+    else:
+        return np.array([amplitudes[i] for i in ordering])
 
 
 def load_wavefunction(file: LoadSource) -> Wavefunction:

--- a/src/orquestra/quantum/wavefunction.py
+++ b/src/orquestra/quantum/wavefunction.py
@@ -224,14 +224,15 @@ def flip_amplitudes(amplitudes: Union[Sequence[complex], np.ndarray]) -> np.ndar
     ordering = _get_ordering(number_of_states)
     return np.asarray(amplitudes)[ordering]
 
+
 @lru_cache
 def _get_ordering(number_of_states: int) -> np.ndarray:
     num_bits = number_of_states.bit_length() - 1
     ordering = (
-        np.arange(2 ** num_bits)
+        np.arange(2**num_bits)
         .reshape(num_bits * [2])
         .transpose(*reversed(range(num_bits)))
-        .reshape(2 ** num_bits)
+        .reshape(2**num_bits)
     )
     return ordering
 


### PR DESCRIPTION
## Description

While using the qulacs simulator, a lot of calls are made to `flip_amplitudes` in `wavefunction.py`. Half of the time of qulacs simulation is spent on this function. This PR is an old fix by @MSRudolph, which significantly speeds up this function.

<img width="625" alt="Screenshot 2022-10-04 at 7 51 50 AM" src="https://user-images.githubusercontent.com/31494271/193823985-8131519c-a231-4031-bfbb-1d6cb9dbf0be.png">

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
