### PR TITLE
fix: make sample_from_wavefunction compatible with numpy 1.24

### DIFF
--- a/src/orquestra/quantum/wavefunction.py
+++ b/src/orquestra/quantum/wavefunction.py
@@ -296,7 +296,9 @@ def sample_from_wavefunction(
         outcome_tuples += convert_bitstrings_to_tuples(outcome_strings)
         outcome_tuples += [0]  # adding non tuple forces rng.choice to return tuples
         probabilities += [0]  # need to add corresponding probability of 0
-        samples = rng.choice(a=outcome_tuples, size=n_samples, p=probabilities).tolist()
+        samples = rng.choice(
+            a=np.array(outcome_tuples, dtype=object), size=n_samples, p=probabilities
+        ).tolist()
     else:
         string_samples = rng.choice(a=outcome_strings, size=n_samples, p=probabilities)
         samples = convert_bitstrings_to_tuples(string_samples)


### PR DESCRIPTION
## Description

With numpy 1.24 creation of ragged arrays always raises `ValueError`, unless `dtype=object` is passed. We used to create jagged arrays without the correct dtype, which is what this PR fixes.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
