### PR TITLE
fix(circuits/_testing.py): create_random_circuit

### DIFF
--- a/src/orquestra/quantum/circuits/_testing.py
+++ b/src/orquestra/quantum/circuits/_testing.py
@@ -61,6 +61,7 @@ def create_random_circuit(
             ONE_QUBIT_ONE_PARAM_GATES,
             TWO_QUBITS_ONE_PARAM_GATES,
         ],
+        dtype=object,
     )
 
     # Loop to add gates to circuit


### PR DESCRIPTION
## Description

Some new versions of numpy no longer have object as the default type of numpy arrays. This was causing issues when numpy noticed the array for all our gates was not homogenous. This PR fixes it.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
