### PR TITLE
feat(circuit.py): add controlled()

### DIFF
--- a/src/orquestra/quantum/circuits/_circuit.py
+++ b/src/orquestra/quantum/circuits/_circuit.py
@@ -165,14 +165,21 @@ class Circuit:
                 " since there are operators in it without the `dagger` method."
             ) from e
 
-    def controlled(self):
+    def controlled(self, control_index) -> "Circuit":
         """Return a circuit where all the operations from self are turned into their
-        respective controlled operations whose control is the 0th qubit."""
+        respective controlled operations whose control is the qubit with index given
+        by control_index.
+
+        Args:
+            control_index: the index for the added qubit used to control the circuit
+                given by self.
+        """
         c_ops = []
         for op in self.operations:
             controlled_op = op.gate.controlled(1)
-            new_qubit_indices = (0, *(i + 1 for i in op.qubit_indices))
-            c_ops.append(controlled_op(*new_qubit_indices))
+            new_indices = (i + 1 if i >= control_index else i for i in op.qubit_indices)
+            new_indices_with_control = (control_index, *new_indices)
+            c_ops.append(controlled_op(*new_indices_with_control))
 
         return Circuit(c_ops)
 

--- a/src/orquestra/quantum/circuits/_circuit.py
+++ b/src/orquestra/quantum/circuits/_circuit.py
@@ -165,6 +165,17 @@ class Circuit:
                 " since there are operators in it without the `dagger` method."
             ) from e
 
+    def controlled(self):
+        """Return a circuit where all the operations from self are turned into their
+        respective controlled operations whose control is the 0th qubit."""
+        c_ops = []
+        for op in self.operations:
+            controlled_op = op.gate.controlled(1)
+            new_qubit_indices = (0, *(i + 1 for i in op.qubit_indices))
+            c_ops.append(controlled_op(*new_qubit_indices))
+
+        return Circuit(c_ops)
+
 
 @singledispatch
 def _append_to_circuit(other, circuit: Circuit):

--- a/src/orquestra/quantum/circuits/_circuit.py
+++ b/src/orquestra/quantum/circuits/_circuit.py
@@ -165,7 +165,7 @@ class Circuit:
                 " since there are operators in it without the `dagger` method."
             ) from e
 
-    def controlled(self, control_index) -> "Circuit":
+    def controlled(self, control_index: int) -> "Circuit":
         """Return a circuit where all the operations from self are turned into their
         respective controlled operations whose control is the qubit with index given
         by control_index.

--- a/tests/orquestra/quantum/circuits/_circuit_test.py
+++ b/tests/orquestra/quantum/circuits/_circuit_test.py
@@ -270,3 +270,26 @@ class TestCircuitInverse:
         circuit = Circuit(operations=[gate])
         with pytest.raises(AttributeError):
             circuit.inverse()
+
+
+@pytest.mark.parametrize(
+    "circuit, target_circuit",
+    [
+        (Circuit([X(0)]), Circuit([X.controlled(1)(0, 1)])),
+        (Circuit([H(0)]), Circuit([H.controlled(1)(0, 1)])),
+        (Circuit([CNOT(0, 1)]), Circuit([CNOT.controlled(1)(0, 1, 2)])),
+        (
+            Circuit([X(0), CNOT(0, 1)]),
+            Circuit([X.controlled(1)(0, 1), CNOT.controlled(1)(0, 1, 2)]),
+        ),
+        (
+            Circuit([X(2), CNOT(0, 1)]),
+            Circuit([X.controlled(1)(0, 3), CNOT.controlled(1)(0, 1, 2)]),
+        ),
+    ],
+)
+def test_controlled_circuit_gives_correct_output(circuit, target_circuit):
+    test_circuit = circuit.controlled()
+
+    assert test_circuit.n_qubits == target_circuit.n_qubits
+    assert test_circuit == target_circuit

--- a/tests/orquestra/quantum/circuits/_circuit_test.py
+++ b/tests/orquestra/quantum/circuits/_circuit_test.py
@@ -273,23 +273,36 @@ class TestCircuitInverse:
 
 
 @pytest.mark.parametrize(
-    "circuit, target_circuit",
+    "circuit, control_index, target_circuit",
     [
-        (Circuit([X(0)]), Circuit([X.controlled(1)(0, 1)])),
-        (Circuit([H(0)]), Circuit([H.controlled(1)(0, 1)])),
-        (Circuit([CNOT(0, 1)]), Circuit([CNOT.controlled(1)(0, 1, 2)])),
+        (Circuit([X(0)]), 0, Circuit([X.controlled(1)(0, 1)])),
+        (Circuit([H(0)]), 0, Circuit([H.controlled(1)(0, 1)])),
+        (Circuit([X(0)]), 1, Circuit([X.controlled(1)(1, 0)])),
+        (Circuit([H(0)]), 4, Circuit([H.controlled(1)(4, 0)])),
+        (Circuit([X(2)]), 1, Circuit([X.controlled(1)(1, 3)])),
+        (Circuit([CNOT(0, 1)]), 0, Circuit([CNOT.controlled(1)(0, 1, 2)])),
+        (Circuit([CNOT(0, 1)]), 1, Circuit([CNOT.controlled(1)(1, 0, 2)])),
         (
             Circuit([X(0), CNOT(0, 1)]),
+            0,
             Circuit([X.controlled(1)(0, 1), CNOT.controlled(1)(0, 1, 2)]),
         ),
         (
             Circuit([X(2), CNOT(0, 1)]),
+            0,
             Circuit([X.controlled(1)(0, 3), CNOT.controlled(1)(0, 1, 2)]),
+        ),
+        (
+            Circuit([X(2), CNOT(0, 1)]),
+            2,
+            Circuit([X.controlled(1)(2, 3), CNOT.controlled(1)(2, 0, 1)]),
         ),
     ],
 )
-def test_controlled_circuit_gives_correct_output(circuit, target_circuit):
-    test_circuit = circuit.controlled()
+def test_controlled_circuit_gives_correct_output(
+    circuit, control_index, target_circuit
+):
+    test_circuit = circuit.controlled(control_index)
 
     assert test_circuit.n_qubits == target_circuit.n_qubits
     assert test_circuit == target_circuit


### PR DESCRIPTION
## Description

To more easily create circuits from Hamiltonians, I have implemented a function for `circuits` which returns the same circuit, except we add one control to each operation. This additional control will be on a qubit which is added to the circuit in the 0th position.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
