### PR TITLE
Fixing various typing issues

### DIFF
--- a/src/orquestra/quantum/circuits/_gates.py
+++ b/src/orquestra/quantum/circuits/_gates.py
@@ -218,8 +218,8 @@ class MatrixFactoryGate:
     def replace_params(self, new_params: Tuple[Parameter, ...]) -> "MatrixFactoryGate":
         return replace(self, params=new_params)
 
-    def controlled(self, num_controlled_qubits: int) -> Gate:
-        return ControlledGate(self, num_controlled_qubits)
+    def controlled(self, num_control_qubits: int) -> Gate:
+        return ControlledGate(self, num_control_qubits)
 
     @property
     def dagger(self) -> Union["MatrixFactoryGate", Gate]:

--- a/src/orquestra/quantum/decompositions/_orquestra_decompositions.py
+++ b/src/orquestra/quantum/decompositions/_orquestra_decompositions.py
@@ -31,7 +31,7 @@ class U3GateToRotation(DecompositionRule[GateOperation]):
         def preprocess_gate(gate):
             return (
                 gate.controlled(operation.gate.num_control_qubits)
-                if operation.gate.name == "Control"
+                if isinstance(operation.gate, ControlledGate)
                 else gate
             )
 


### PR DESCRIPTION
## Description

This pull request addresses two minor typing issues:
* `MatrixFactoryGate.controlled` did not use the same parameter name as the `controlled` method of the `Gate` protocol.
* One of the decomposition rules tried to access the `num_control_qubits` attributes of a gate without ensuring that the gate is of type `ControlledGate`.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
